### PR TITLE
bdStorage.json workaround/fix

### DIFF
--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -88,6 +88,8 @@ echo
 echo --- Finishing up ---
 cd $HOME/.config/betterdiscord/BetterDiscordApp-stable16/lib
 sudo mv Utils.js utils.js
+cd /var/local/BetterDiscord #Added to go to directory of bdstorage.json
+mv bdstorage.json bdStorage.json #Added to rename bdStorage.json so BetterDiscord can find it
 echo
 echo \#####################
 echo \# Launching Discord \#

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -87,7 +87,7 @@ sudo ./node_modules/.bin/electron ./src
 echo
 echo --- Finishing up ---
 cd $HOME/.config/betterdiscord/BetterDiscordApp-stable16/lib
-sudo mv Utils.js utils.js
+sudo ln -f -s utils.js Utils.js #Symlink as it's safer than renaming files.
 echo
 echo \#####################
 echo \# Launching Discord \#

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -95,6 +95,7 @@ echo \#####################
 cd $HOME
 ### Enable if using Canary build; it's just for compatibility. Use "discord-canary" after. 
 ## alias discord="discord-canary"
+echo -e "Don't exit this script yet, wait for better discord to finish loading, and close Discord, than the script will finish setting up"
 discord
 ln -f -s ~/BetterDiscord/bdStorage.json ~/BetterDiscord/bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
 echo

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -97,7 +97,9 @@ cd $HOME
 ## alias discord="discord-canary"
 echo -e "Don't exit this script yet, wait for better discord to finish loading, and close Discord, than the script will finish setting up"
 discord
-ln -f -s /var/local/BetterDiscord/bdStorage.json /var/local/BetterDiscord/bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
+cd /var/local/BetterDiscord
+ln -f -s bdStorage.json bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
+cd $HOME
 sudo chmod -R 777 ~/.config/betterdiscord/BetterDiscordApp-stable16/
 echo
 echo --- Script end ---

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -88,7 +88,6 @@ echo
 echo --- Finishing up ---
 cd $HOME/.config/betterdiscord/BetterDiscordApp-stable16/lib
 sudo mv Utils.js utils.js
-mv ~/BetterDiscord/bdstorage.json ~/BetterDiscord/bdStorage.json #Added to rename bdStorage.json so BetterDiscord can find it
 echo
 echo \#####################
 echo \# Launching Discord \#
@@ -96,7 +95,8 @@ echo \#####################
 cd $HOME
 ### Enable if using Canary build; it's just for compatibility. Use "discord-canary" after. 
 ## alias discord="discord-canary"
-discord &
+discord
+ln -f -s ~/BetterDiscord/bdStorage.json ~/BetterDiscord/bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
 echo
 echo --- Script end ---
 exit

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -62,8 +62,6 @@ cd ./betterdiscordapp/Installers/Electron
 npm install
 npm install --save-dev electron
 echo
-echo --- Doing other user-enhancing things... ---
-mkdir -p $HOME/.config/betterdiscord
 # Since script will be ran as sudo, this has to be done so permission issues are prevented.
 # Method changed to giving read/write access to everyone.
 sudo chmod -R 777 /var/local/BetterDiscord

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -65,8 +65,8 @@ echo
 echo --- Doing other user-enhancing things... ---
 mkdir -p $HOME/.config/betterdiscord
 # Since script will be ran as sudo, this has to be done so permission issues are prevented.
-mkdir -p $HOME/BetterDiscord
-sudo ln -s $HOME/BetterDiscord /var/local/BetterDiscord
+# Method changed to giving read/write access to everyone.
+sudo chmod -R 777 /var/local/BetterDiscord/
 echo
 echo --- Launching BetterDiscord Installer ---
 echo -e "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -98,6 +98,7 @@ cd $HOME
 echo -e "Don't exit this script yet, wait for better discord to finish loading, and close Discord, than the script will finish setting up"
 discord
 ln -f -s ~/BetterDiscord/bdStorage.json ~/BetterDiscord/bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
+sudo chmod -R 777 ~/.config/betterdiscord/BetterDiscordApp-stable16/
 echo
 echo --- Script end ---
 exit

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -88,8 +88,7 @@ echo
 echo --- Finishing up ---
 cd $HOME/.config/betterdiscord/BetterDiscordApp-stable16/lib
 sudo mv Utils.js utils.js
-cd /var/local/BetterDiscord #Added to go to directory of bdstorage.json
-mv bdstorage.json bdStorage.json #Added to rename bdStorage.json so BetterDiscord can find it
+mv ~/BetterDiscord/bdstorage.json ~/BetterDiscord/bdStorage.json #Added to rename bdStorage.json so BetterDiscord can find it
 echo
 echo \#####################
 echo \# Launching Discord \#

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -97,7 +97,7 @@ cd $HOME
 ## alias discord="discord-canary"
 echo -e "Don't exit this script yet, wait for better discord to finish loading, and close Discord, than the script will finish setting up"
 discord
-ln -f -s ~/BetterDiscord/bdStorage.json ~/BetterDiscord/bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
+ln -f -s /var/local/BetterDiscord/bdStorage.json /var/local/BetterDiscord/bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
 sudo chmod -R 777 ~/.config/betterdiscord/BetterDiscordApp-stable16/
 echo
 echo --- Script end ---

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -62,6 +62,8 @@ cd ./betterdiscordapp/Installers/Electron
 npm install
 npm install --save-dev electron
 echo
+echo --- Doing other user-enhancing things... ---
+mkdir -p $HOME/.config/betterdiscord
 # Since script will be ran as sudo, this has to be done so permission issues are prevented.
 # Method changed to giving read/write access to everyone.
 sudo chmod -R 777 /var/local/BetterDiscord
@@ -95,9 +97,7 @@ cd $HOME
 ## alias discord="discord-canary"
 echo -e "Don't exit this script yet, wait for better discord to finish loading, and close Discord, than the script will finish setting up"
 discord
-cd /var/local/BetterDiscord
-ln -f -s bdStorage.json bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
-cd $HOME
+ln -f -s ~/BetterDiscord/bdStorage.json ~/BetterDiscord/bdstorage.json #So it can read your saved settings despite BetterDiscord, mistakenly saving this file as bdstorage.json but trying to read as bdStorage.json at startup.
 sudo chmod -R 777 ~/.config/betterdiscord/BetterDiscordApp-stable16/
 echo
 echo --- Script end ---

--- a/betterdiscordoneshot.sh
+++ b/betterdiscordoneshot.sh
@@ -66,7 +66,7 @@ echo --- Doing other user-enhancing things... ---
 mkdir -p $HOME/.config/betterdiscord
 # Since script will be ran as sudo, this has to be done so permission issues are prevented.
 # Method changed to giving read/write access to everyone.
-sudo chmod -R 777 /var/local/BetterDiscord/
+sudo chmod -R 777 /var/local/BetterDiscord
 echo
 echo --- Launching BetterDiscord Installer ---
 echo -e "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"


### PR DESCRIPTION
Symlinks bdStorage.json (what BetterDiscord tries to read) with bdstorage.json (what it saves as) so it could read the data saved in bdstorage.json correctly, despite that problem.
(enables discord to relaunch with BetterDiscord, have no errors, and read your saved data, while a rename does sorta fix it, it would just reset some of your custom settings everytime like CustomCSS)

@Hebgbs 